### PR TITLE
YANK files for hydration free energy calculations.

### DIFF
--- a/yank/freesolv-mini.smiles
+++ b/yank/freesolv-mini.smiles
@@ -1,0 +1,8 @@
+# Extracted from Hydration free energy datbase v0.5, 1/19/17.
+# Semicolon-delimited text file with fields in the following format:
+# compound id (and file prefix); SMILES; iupac name (or alternative if IUPAC is unavailable or not parseable by OEChem); experimental value (kcal/mol); experimental uncertainty (kcal/mol); Mobley group calculated value (GAFF) (kcal/mol); calculated uncertainty (kcal/mol); experimental reference (original or paper this value was taken from); calculated reference; text notes.
+mobley_1723043; C1(C(C(C1(F)F)(F)F)(F)F)(F)F; octafluorocyclobutane; 3.43; 0.03; 3.08; 0.03; 10.1007/s10822-010-9350-8; 10.1007/s10822-010-9343-7; Experimental uncertainty not presently available, so assigned a default value.
+mobley_1873346; Cc1ccccc1; toluene; -0.90; 0.20; -0.79; 0.03; 10.1039/P29900000291; 10.1021/jp0667442; Experimental uncertainty as suggested by 10.1039/P29900000291 -- 0.2 kcal/mol.
+mobley_4883284; c1ccc(cc1)N; aniline; -5.49; 0.60; -5.54; 0.03; 10.1021/ct050097l; 10.1021/ct800409d; Experimental uncertainty not presently available, so assigned a default value.
+mobley_8048190; CC(=O)N; acetamide; -9.71; 0.60; -8.82; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; Experimental uncertainty not presently available, so assigned a default value.
+mobley_2727678; c1c(c(=O)[nH]c(=O)[nH]1)I; 5-iodouracil; -18.72; 0.64; -17.74; 0.03; 10.1007/s10822-010-9350-8; 10.1007/s10822-010-9343-7; Experimental uncertainty not presently available, so assigned a default value.

--- a/yank/freesolv_template.yaml
+++ b/yank/freesolv_template.yaml
@@ -1,0 +1,56 @@
+---
+options:
+  minimize: yes
+  verbose: no
+  output_dir: .
+  experiments_dir: experiments/{experiments_dir}
+  checkpoint_interval: 50
+  temperature: 298.15*kelvin
+  pressure: 1*atmosphere
+  constraints: HBonds
+  timestep: 2*femtoseconds
+  nsteps_per_iteration: 500
+  number_of_iterations: 5000
+  anisotropic_dispersion_cutoff: 16.0*angstroms
+
+molecules:
+  molecule:
+    filepath: freesolv-mini.smiles
+    openeye:
+      quacpac: am1-bcc
+    antechamber:
+      charge_method: null
+    select: all
+
+solvents:
+  water:
+    nonbonded_method: PME
+    nonbonded_cutoff: 11*angstroms
+    switch_distance: 10*angstroms
+    ewald_error_tolerance: 1.0e-5
+    clearance: 14*angstroms
+  vacuum:
+    nonbonded_method: NoCutoff
+
+systems:
+  hydration-system:
+    solute: molecule
+    solvent1: water
+    solvent2: vacuum
+    leap:
+      parameters: [leaprc.gaff, leaprc.protein.ff14SB, leaprc.water.tip3p]
+
+protocols:
+  hydration-protocol:
+    solvent1:
+      alchemical_path:
+        lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+        lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00, 0.95, 0.90, 0.80, 0.70, 0.60, 0.50, 0.40, 0.35, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05, 0.00]
+    solvent2:
+      alchemical_path:
+        lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00]
+        lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00]
+
+experiments:
+  system: hydration-system
+  protocol: hydration-protocol

--- a/yank/run_yank.py
+++ b/yank/run_yank.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+
+from simtk import unit
+from openmmtools import mcmc
+from yank.yamlbuild import YamlBuilder
+
+
+def run_yank(yank_script_template_filepath):
+    # Read in YAML script template. We will use it to set
+    # the output folder for each experiment.
+    with open(yank_script_template_filepath, 'r') as f:
+        script_template = f.read()
+
+    # Generate all combinations.
+    for timestep in [1.5]*unit.femtosecond:
+        for mcmc_move in [mcmc.LangevinDynamicsMove(timestep=timestep)]:
+
+            # Create unique name name for the output of the experiments.
+            # The " * 10" is just to avoid having dots in the directory name.
+            experiment_dir = 'timestep{}-{}'.format(int(timestep * 10 / unit.femtosecond),
+                                                    mcmc_move.__class__.__name__)
+            script = script_template.format(experiments_dir=experiment_dir)
+
+            # Build experiment for all molecules in the YAML script.
+            yamlbuilder = YamlBuilder(script)
+            for experiment in yamlbuilder.build_experiments():
+
+                # Set the MCMC Move (YANK's default is LangevinDynamics).
+                for phase in experiment.phases:
+                    phase.sampler.mcmc_moves = mcmc_move
+
+                # Run experiment.
+                experiment.run()
+
+
+
+if __name__ == '__main__':
+    run_yank('freesolv_template.yaml')


### PR DESCRIPTION
The YAML script and `freesolv-mini.smiles` were taken from the yank-validation repo. I've also sketched a `run_yank.py` script that generates the combinations of `timestep`s and `MCMCMove`s. Currently it runs all the 5 molecules in `freesolv-mini.smiles`, but you can change it if you want to run only a subset. Let me know if there's something unclear or there's something else you'd like to do!